### PR TITLE
fix: 即抜けRTAのタイムが60秒以上であったときにbreakしていなかった

### DIFF
--- a/src/listeners/rta/exitMembers.ts
+++ b/src/listeners/rta/exitMembers.ts
@@ -24,6 +24,7 @@ export class ExitGuildMember extends Listener {
         const rtaTime = joinDate - date
         if(60 <= rtaTime) {
             logger.info(`Member(id: ${member.id}) is not RTA Player.`)
+            return
         }
 
         const embed = new EmbedBuilder()


### PR DESCRIPTION
ここでreturnしていなかったため、秒数が指定以上であっても問答無用で即抜けRTAが実施されていた